### PR TITLE
Fixed redirection on incorrect password

### DIFF
--- a/src/hooks/use-signin/useSignin.ts
+++ b/src/hooks/use-signin/useSignin.ts
@@ -1,5 +1,7 @@
 import { signIn, SignInResponse } from "next-auth/react"
 import { useState } from "react"
+import { useRouter } from "next/navigation"
+import routes from "@/constants/routes"
 import { Credentials } from "@/types/types"
 
 const useSignin = () => {
@@ -7,17 +9,24 @@ const useSignin = () => {
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const [data, setData] = useState<SignInResponse | null>(null)
 
+  const router = useRouter()
+
   const signin = async (data: Credentials) => {
     setIsLoading(true)
 
     const res = await signIn("credentials", {
       callbackUrl: "/admin/dashboard/indicators",
+      redirect: false,
       ...data,
     })
 
     setData(res || null)
     setIsLoading(false)
     setStatus(res?.status || null)
+
+    if (res?.status === 200) {
+      router.push(routes.admin.indicators)
+    }
   }
 
   const isSuccess = status === 200


### PR DESCRIPTION
There was an error related to signin. User was redirected when incorrect password was submitted (incorrect but correct in terms of client validation). 

I needed to disable redirection in next auth signin config. Previously I used it to automatically redirect on success, but didn't notice it redirects on error too. I replaced redirection on success with simple client `router.push()`.