### PR TITLE
Added e2e tests grouping

### DIFF
--- a/e2e/cypress.config.ts
+++ b/e2e/cypress.config.ts
@@ -37,9 +37,10 @@ async function setupNodeEvents(
       return 0;
     },
     clearTestDatabase: async () => {
+      await prisma.value.deleteMany();
+
       await Promise.all([
         prisma.user.deleteMany(),
-        prisma.value.deleteMany(),
         prisma.country.deleteMany(),
         prisma.indicator.deleteMany(),
       ]);
@@ -88,7 +89,11 @@ async function setupNodeEvents(
 }
 
 export default defineConfig({
-  env: { ...envs },
+  env: {
+    ...envs,
+    omitFiltered: true,
+    filterSpecs: true,
+  },
   e2e: {
     baseUrl: "http://localhost:3000",
     specPattern: "**/*.feature",

--- a/e2e/cypress/tests/footer/footer.feature
+++ b/e2e/cypress/tests/footer/footer.feature
@@ -1,8 +1,10 @@
+@layout
 Feature: Footer
 
   Background: Footer Background
     Given I am on the landing page
 
+  @smoke @navigation
   Scenario Outline: User navigates throught footer links
     And I see footer
     When I click "<label>"

--- a/e2e/cypress/tests/landing-page/landing-page.feature
+++ b/e2e/cypress/tests/landing-page/landing-page.feature
@@ -1,23 +1,28 @@
+@page
 Feature: Landing page
 
   Background: Landing page Background
     Given I am on the landing page
 
+  @smoke
   Scenario: Verify lading page content
     When the landing page has finished loading
     And I should see a heading
     And I should see a description
     And I should see a searchbar
 
+  @feature
   Scenario: Suggest indicators as I type in the search bar
     When I type "GDP" in the searchbar
     Then I should see a list of suggested indicators
 
+  @feature
   Scenario: Removes search value after I clear it
     When I type "life expectency" in the searchbar
     And clear input value
     Then I should see empty search input
 
+  @navigation @regression
   Scenario: Navigates to search page
     When I type "GDP" in the searchbar
     And submit form

--- a/e2e/cypress/tests/search/search.feature
+++ b/e2e/cypress/tests/search/search.feature
@@ -1,13 +1,16 @@
+@page
 Feature: Search page
 
   Background: Search page Background
     Given I am on a search page
 
+  @feature @regression
   Scenario: I see search results
     When I type "GDP" in the searchbar
     And submit form
     Then I should see at least one result
 
+  @navigation @regression
   Scenario: I open indicator page of the first indicator of the results
     When I type "GDP" in the searchbar
     And submit form

--- a/e2e/cypress/tests/toolbar/toolbar.feature
+++ b/e2e/cypress/tests/toolbar/toolbar.feature
@@ -1,22 +1,27 @@
+@layout
 Feature: Toolbar functionality
 
   Background: Toolbar background
     Given I am on the search page
 
+  @feature
   Scenario: Suggest indicators as I type in the search bar
     When I type "GDP" in the searchbar
     Then I should see a list of suggested indicators
 
+  @feature
   Scenario: Removes search value after I clear it
     When I type "life expectency" in the searchbar
     And clear input value
     Then I should see empty search input
 
+  @navigation @regression
   Scenario: Navigates to search page
     When I type "GDP" in the searchbar
     And submit form
     Then I should be navigated to "search" page
 
+  @navigation
   Scenario: User navigates to bookmarks page
     And I see footer
     When I click "Bookmarks"

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -3,7 +3,13 @@
   "version": "1.0.0",
   "scripts": {
     "cypress:open": "cypress open",
-    "cypress:run": "cypress run --browser chrome"
+    "cypress:open:smoke": "cypress open --browser chrome -e TAGS=\"@smoke\"",
+    "cypress:open:feature": "cypress open --browser chrome -e TAGS=\"@feature\"",
+    "cypress:open:regression": "cypress open --browser chrome -e TAGS=\"@regression\"",
+    "cypress:run": "cypress run --browser chrome",
+    "cypress:run:smoke": "cypress run --browser chrome -e TAGS=\"@smoke\"",
+    "cypress:run:feature": "cypress run --browser chrome -e TAGS=\"@feature\"",
+    "cypress:run:regression": "cypress run --browser chrome -e TAGS=\"@regression\""
   },
   "author": "Heorhii Shvab",
   "license": "ISC",


### PR DESCRIPTION
- Added e2e tests grouping. Currently, there are 5 tags.
- Added scripts to run regression, smoke and feature tests.